### PR TITLE
Use relative paths in run-create-wqx-activities-and-results.sh

### DIFF
--- a/scripts/wqx/run-create-wqx-activities-and-results.sh
+++ b/scripts/wqx/run-create-wqx-activities-and-results.sh
@@ -5,12 +5,12 @@
 # This script wraps the create-wqx-activities-and-results.js script to make
 # passing in parameters easier.
 # Args:
-# $1 the name of the directory in ~/hui-reports/scripts/wqx/check-wqx/wqx-wqp-downloads where the WQX current download results file is stored
+# $1 the name of the directory in ./check-wqx/wqx-wqp-downloads where the WQX current download results file is stored
 # $2 a basename for the output files that are created in the process and stored in ./load-files
 #
 # example: ./run-create-wqx-activities-and-results.sh  20241203a-wqx-3rd-quarter-2024-sync-prep 2024-3rd-quarter.0
 #
-# resulting files found in ~/hui-reports/scripts/wqx/load-files :
+# resulting files found in ./load-files :
 #
 #  2024-3rd-quarter.0.existing-update.txt
 #  2024-3rd-quarter.0.new-add.txt
@@ -26,8 +26,7 @@ then
   exit 1
 fi
 
-# TODO - don't hard code path
-wqxDownloadsDir=~/hui/hui-reports/scripts/wqx/check-wqx/wqx-wqp-downloads
+wqxDownloadsDir=./check-wqx/wqx-wqp-downloads
 wqxResultsDetailExportFile="$wqxDownloadsDir/$1/Result Detail Export.txt"
 basename=$2
 
@@ -42,8 +41,8 @@ fi
 ./create-wqx-activities-and-results.js  \
     -o ./load-files  \
     -b $basename  \
-    -g ~/hui/hui-reports/data/google-drive-downloads/ \
-    -n ~/hui/hui-reports/data/nutrient-data/  \
+    -g ../../data/google-drive-downloads/ \
+    -n ../../data/nutrient-data/  \
     -w "$wqxResultsDetailExportFile"
 
 exit 0


### PR DESCRIPTION
## Summary
- Replaced hardcoded `~/hui/hui-reports/...` paths with relative paths (`./` and `../../`) in `run-create-wqx-activities-and-results.sh`
- Updated comments in the script header to also reflect relative paths
- Removes the `# TODO - don't hard code path` comment, as the issue is now resolved

## Test plan
- [ ] Run `./run-create-wqx-activities-and-results.sh` from the `scripts/wqx/` directory and verify it locates the WQX downloads and output files correctly using the relative paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)